### PR TITLE
Add EBC zoom overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# macOS
+.DS_Store
+images/.DS_Store

--- a/css/style.css
+++ b/css/style.css
@@ -148,3 +148,68 @@ body {
 .fa-linkedin {
   color: #007bb6;
 }
+
+/* Zoom overlay styles for the Everest Base Camp map */
+.zoom-overlay {
+  display: none;
+  position: fixed;
+  z-index: 9999;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.zoom-overlay.open {
+  display: flex;
+}
+
+.zoom-content {
+  max-width: 1100px;
+  width: 100%;
+  margin: 0 auto;
+  position: relative;
+}
+
+.zoom-close {
+  position: absolute;
+  right: 0;
+  top: -10px;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-size: 36px;
+  cursor: pointer;
+}
+
+.zoom-map {
+  width: 100%;
+  height: auto;
+  max-height: 70vh;
+  object-fit: contain;
+  display: block;
+  margin-bottom: 20px;
+  border-radius: 4px;
+}
+
+.zoom-info h2 {
+  margin-top: 0;
+  font-size: 20px;
+}
+
+.zoom-info .route,
+.zoom-info .relevant {
+  font-size: 16px;
+  line-height: 1.4;
+}
+
+/* Hide all other content when zoom overlay is open */
+body.zoom-open > :not(.zoom-overlay) {
+  display: none !important;
+}

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -114,10 +114,14 @@
           <div class="col-md-2">
             <a
               href="https://coderbear.com/ebc-dashboard"
-              class="override-link"
+              class="override-link ebc-link"
               target="_blank"
-              ><img src="images/EBC.png" width="50" class="override-link"
-            /></a>
+              ><img
+                src="images/EBC.png"
+                width="50"
+                class="override-link ebc-thumb"
+                alt="Everest Base Camp thumbnail"
+              /></a>
             <div class="link-desc">
               <a
                 href="https://coderbear.com/ebc-dashboard"
@@ -170,6 +174,19 @@
       </div>
     </div>
 
+    <!-- Zoom overlay: opens when the EBC thumbnail is clicked. Hides all other page content while open and shows only relevant names and the route. -->
+    <div class="zoom-overlay" role="dialog" aria-modal="true" aria-hidden="true">
+      <div class="zoom-content">
+        <button class="zoom-close" aria-label="Close zoom">&times;</button>
+        <img src="images/EBC.png" class="zoom-map" alt="Everest Base Camp map" />
+        <div class="zoom-info">
+          <h2>Everest Base Camp Route</h2>
+          <p class="route"><strong>Route:</strong> Kathmandu → Lukla → Namche Bazaar → Tengboche → Dingboche → Lobuche → Everest Base Camp</p>
+          <p class="relevant"><strong>Relevant names:</strong> Lukla, Namche Bazaar, Tengboche, Dingboche, Lobuche, Everest Base Camp</p>
+        </div>
+      </div>
+    </div>
+
     <script>
       (function (i, s, o, g, r, a, m) {
         i["GoogleAnalyticsObject"] = r;
@@ -192,6 +209,61 @@
       );
       ga("create", "UA-59342737-1", "auto");
       ga("send", "pageview");
+    </script>
+
+    <script>
+      // JS to open the zoom overlay and hide other page content
+      (function () {
+        var ebcThumb = document.querySelector('.ebc-thumb');
+        var overlay = document.querySelector('.zoom-overlay');
+        var closeBtn = document.querySelector('.zoom-close');
+
+        function openOverlay(e) {
+          e && e.preventDefault();
+          if (!overlay) return;
+          overlay.setAttribute('aria-hidden', 'false');
+          overlay.classList.add('open');
+          // add class to body so CSS can hide page content
+          document.body.classList.add('zoom-open');
+          // mark main content as hidden for screen readers
+          var main = document.querySelector('.main-frame');
+          if (main) main.setAttribute('aria-hidden', 'true');
+          // focus the close button for accessibility
+          closeBtn && closeBtn.focus();
+        }
+
+        function closeOverlay() {
+          if (!overlay) return;
+          overlay.setAttribute('aria-hidden', 'true');
+          overlay.classList.remove('open');
+          document.body.classList.remove('zoom-open');
+          var main = document.querySelector('.main-frame');
+          if (main) main.removeAttribute('aria-hidden');
+        }
+
+        if (ebcThumb) {
+          ebcThumb.style.cursor = 'zoom-in';
+          var parentLink = ebcThumb.closest('a');
+          if (parentLink) {
+            parentLink.addEventListener('click', function (ev) {
+              ev.preventDefault();
+              openOverlay(ev);
+            });
+          } else {
+            ebcThumb.addEventListener('click', openOverlay);
+          }
+        }
+
+        closeBtn && closeBtn.addEventListener('click', closeOverlay);
+        // close when clicking outside content
+        overlay && overlay.addEventListener('click', function (ev) {
+          if (ev.target === overlay) closeOverlay();
+        });
+        // close on escape
+        document.addEventListener('keydown', function (ev) {
+          if (ev.key === 'Escape') closeOverlay();
+        });
+      })();
     </script>
   </body>
 </html>


### PR DESCRIPTION
Adds a zoom overlay to the Everest Base Camp image that shows only relevant names and route while hiding other page content when opened.